### PR TITLE
Dev (#290)

### DIFF
--- a/src/MiningCore.Tests/Blockchain/Ethereum/EthereumJobTests.cs
+++ b/src/MiningCore.Tests/Blockchain/Ethereum/EthereumJobTests.cs
@@ -14,7 +14,7 @@ namespace MiningCore.Tests.Blockchain.Ethereum
 	/// </summary>
 	public class EthereumJobTests : TestBase
     {
-        static readonly EthashFull ethash = new EthashFull(3, Path.GetTempPath(), true);
+        static readonly EthashFull ethash = new EthashFull(3, Path.GetTempPath());
 
 		/*
         [Fact]

--- a/src/MiningCore.Tests/Crypto/EthashTests.cs
+++ b/src/MiningCore.Tests/Crypto/EthashTests.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 using MiningCore.Crypto.Hashing.Algorithms;
 using MiningCore.Crypto.Hashing.Ethash;
 using MiningCore.Extensions;
+using NLog;
 using Xunit;
 
 namespace MiningCore.Tests.Crypto
 {
     public class EthashTests : TestBase
     {
+        private ILogger logger = LogManager.GetCurrentClassLogger();
+
         [Fact]
         public async Task Ethhash_Verify_Valid_Blocks()
         {
@@ -47,9 +50,9 @@ namespace MiningCore.Tests.Crypto
 
             using (var ethash = new EthashLight(3))
             {
-                Assert.True(await ethash.VerifyBlockAsync(validBlocks[0]));
-                Assert.True(await ethash.VerifyBlockAsync(validBlocks[1]));
-                Assert.True(await ethash.VerifyBlockAsync(validBlocks[2]));
+                Assert.True(await ethash.VerifyBlockAsync(validBlocks[0], logger));
+                Assert.True(await ethash.VerifyBlockAsync(validBlocks[1], logger));
+                Assert.True(await ethash.VerifyBlockAsync(validBlocks[2], logger));
             }
         }
 
@@ -99,10 +102,10 @@ namespace MiningCore.Tests.Crypto
 
             using (var ethash = new EthashLight(3))
             {
-                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[0]));
-                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[1]));
-                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[2]));
-                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[3]));
+                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[0], logger));
+                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[1], logger));
+                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[2], logger));
+                Assert.False(await ethash.VerifyBlockAsync(invalidBlocks[3], logger));
             }
         }
 
@@ -111,7 +114,7 @@ namespace MiningCore.Tests.Crypto
         {
             using (var ethash = new EthashLight(3))
             {
-                await Assert.ThrowsAsync<ArgumentNullException>(async () => await ethash.VerifyBlockAsync(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(async () => await ethash.VerifyBlockAsync(null, logger));
             }
         }
     }

--- a/src/MiningCore/Api/ApiServer.cs
+++ b/src/MiningCore/Api/ApiServer.cs
@@ -132,7 +132,7 @@ namespace MiningCore.Api
             return null;
         }
 
-        private async Task SendJson(HttpContext context, object response)
+        private async Task SendJsonAsync(HttpContext context, object response)
         {
             context.Response.ContentType = "application/json";
 
@@ -250,7 +250,7 @@ namespace MiningCore.Api
                 }).ToArray()
             };
 
-            await SendJson(context, response);
+            await SendJsonAsync(context, response);
         }
 
         private async Task GetPoolInfoAsync(HttpContext context, Match m)
@@ -280,7 +280,7 @@ namespace MiningCore.Api
                 .Select(mapper.Map<MinerPerformanceStats>)
                 .ToArray();
 
-            await SendJson(context, response);
+            await SendJsonAsync(context, response);
         }
 
         private async Task GetPoolPerformanceAsync(HttpContext context, Match m)
@@ -301,7 +301,7 @@ namespace MiningCore.Api
                 Stats = stats.Select(mapper.Map<AggregatedPoolStats>).ToArray()
             };
 
-            await SendJson(context, response);
+            await SendJsonAsync(context, response);
         }
 
         private async Task PagePoolMinersAsync(HttpContext context, Match m)
@@ -328,7 +328,7 @@ namespace MiningCore.Api
                 .Select(mapper.Map<MinerPerformanceStats>)
                 .ToArray();
 
-            await SendJson(context, miners);
+            await SendJsonAsync(context, miners);
         }
 
         private async Task PagePoolBlocksPagedAsync(HttpContext context, Match m)
@@ -371,7 +371,7 @@ namespace MiningCore.Api
                 }
             }
 
-            await SendJson(context, blocks);
+            await SendJsonAsync(context, blocks);
         }
 
         private async Task PagePoolPaymentsAsync(HttpContext context, Match m)
@@ -409,7 +409,7 @@ namespace MiningCore.Api
                     payment.AddressInfoLink = string.Format(addressInfobaseUrl, payment.Address);
             }
 
-            await SendJson(context, payments);
+            await SendJsonAsync(context, payments);
         }
 
         private async Task GetMinerInfoAsync(HttpContext context, Match m)
@@ -450,7 +450,7 @@ namespace MiningCore.Api
                 stats.PerformanceSamples = GetMinerPerformanceInternal(perfMode, pool, address);
             }
 
-            await SendJson(context, stats);
+            await SendJsonAsync(context, stats);
         }
 
         private async Task PageMinerPaymentsAsync(HttpContext context, Match m)
@@ -495,7 +495,7 @@ namespace MiningCore.Api
                     payment.AddressInfoLink = string.Format(addressInfobaseUrl, payment.Address);
             }
 
-            await SendJson(context, payments);
+            await SendJsonAsync(context, payments);
         }
 
         private async Task PageMinerBalanceChangesAsync(HttpContext context, Match m)
@@ -525,7 +525,7 @@ namespace MiningCore.Api
                 .Select(mapper.Map<Responses.BalanceChange>)
                 .ToArray();
 
-            await SendJson(context, balanceChanges);
+            await SendJsonAsync(context, balanceChanges);
         }
 
         private async Task GetMinerPerformanceAsync(HttpContext context, Match m)
@@ -544,14 +544,14 @@ namespace MiningCore.Api
             var mode = context.GetQueryParameter<string>("mode", "day").ToLower(); // "day" or "month"
             var result = GetMinerPerformanceInternal(mode, pool, address);
 
-            await SendJson(context, result);
+            await SendJsonAsync(context, result);
         }
 
         private async Task HandleForceGcAsync(HttpContext context, Match m)
         {
             GC.Collect(2, GCCollectionMode.Forced);
 
-            await SendJson(context, true);
+            await SendJsonAsync(context, true);
         }
 
         private async Task HandleGcStatsAsync(HttpContext context, Match m)
@@ -562,7 +562,7 @@ namespace MiningCore.Api
             Program.gcStats.GcGen2 = GC.CollectionCount(2);
             Program.gcStats.MemAllocated = FormatUtil.FormatCapacity(GC.GetTotalMemory(false));
 
-            await SendJson(context, Program.gcStats);
+            await SendJsonAsync(context, Program.gcStats);
         }
 
 #region API-Surface

--- a/src/MiningCore/Blockchain/Bitcoin/BitcoinConstants.cs
+++ b/src/MiningCore/Blockchain/Bitcoin/BitcoinConstants.cs
@@ -69,17 +69,75 @@ namespace MiningCore.Blockchain.Bitcoin
         public static readonly BigInteger Diff1 = BigInteger.Parse("00ffff0000000000000000000000000000000000000000000000000000", NumberStyles.HexNumber);
         public const int CoinbaseMinConfimations = 102;
 
-        public const int ErrorMethodNotFound = -32601;
-
         public const string ZmqPublisherTopicBlockHash = "hashblock";
         public const string ZmqPublisherTopicTxHash = "hashtx";
         public const string ZmqPublisherTopicBlockRaw = "rawblock";
         public const string ZmqPublisherTopicTxRaw = "rawtx";
     }
 
-    public class KnownAddresses
+    public enum BitcoinRPCErrorCode
     {
-        public static readonly Dictionary<CoinType, string> DevFeeAddresses = new Dictionary<CoinType, string>
+        //! Standard JSON-RPC 2.0 errors
+        // RPC_INVALID_REQUEST is internally mapped to HTTP_BAD_REQUEST (400).
+        // It should not be used for application-layer errors.
+        RPC_INVALID_REQUEST = -32600,
+        // RPC_METHOD_NOT_FOUND is internally mapped to HTTP_NOT_FOUND (404).
+        // It should not be used for application-layer errors.
+        RPC_METHOD_NOT_FOUND = -32601,
+        RPC_INVALID_PARAMS = -32602,
+        // RPC_INTERNAL_ERROR should only be used for genuine errors in bitcoind
+        // (for example datadir corruption).
+        RPC_INTERNAL_ERROR = -32603,
+        RPC_PARSE_ERROR = -32700,
+
+        //! General application defined errors
+        RPC_MISC_ERROR = -1,  //!< std::exception thrown in command handling
+        RPC_FORBIDDEN_BY_SAFE_MODE = -2,  //!< Server is in safe mode, and command is not allowed in safe mode
+        RPC_TYPE_ERROR = -3,  //!< Unexpected type was passed as parameter
+        RPC_INVALID_ADDRESS_OR_KEY = -5,  //!< Invalid address or key
+        RPC_OUT_OF_MEMORY = -7,  //!< Ran out of memory during operation
+        RPC_INVALID_PARAMETER = -8,  //!< Invalid, missing or duplicate parameter
+        RPC_DATABASE_ERROR = -20, //!< Database error
+        RPC_DESERIALIZATION_ERROR = -22, //!< Error parsing or validating structure in raw format
+        RPC_VERIFY_ERROR = -25, //!< General error during transaction or block submission
+        RPC_VERIFY_REJECTED = -26, //!< Transaction or block was rejected by network rules
+        RPC_VERIFY_ALREADY_IN_CHAIN = -27, //!< Transaction already in chain
+        RPC_IN_WARMUP = -28, //!< Client still warming up
+        RPC_METHOD_DEPRECATED = -32, //!< RPC method is deprecated
+
+        //! Aliases for backward compatibility
+        RPC_TRANSACTION_ERROR = RPC_VERIFY_ERROR,
+        RPC_TRANSACTION_REJECTED = RPC_VERIFY_REJECTED,
+        RPC_TRANSACTION_ALREADY_IN_CHAIN = RPC_VERIFY_ALREADY_IN_CHAIN,
+
+        //! P2P client errors
+        RPC_CLIENT_NOT_CONNECTED = -9,  //!< Bitcoin is not connected
+        RPC_CLIENT_IN_INITIAL_DOWNLOAD = -10, //!< Still downloading initial blocks
+        RPC_CLIENT_NODE_ALREADY_ADDED = -23, //!< Node is already added
+        RPC_CLIENT_NODE_NOT_ADDED = -24, //!< Node has not been added before
+        RPC_CLIENT_NODE_NOT_CONNECTED = -29, //!< Node to disconnect not found in connected nodes
+        RPC_CLIENT_INVALID_IP_OR_SUBNET = -30, //!< Invalid IP/Subnet
+        RPC_CLIENT_P2P_DISABLED = -31, //!< No valid connection manager instance found
+
+        //! Wallet errors
+        RPC_WALLET_ERROR = -4,  //!< Unspecified problem with wallet (key not found etc.)
+        RPC_WALLET_INSUFFICIENT_FUNDS = -6,  //!< Not enough funds in wallet or account
+        RPC_WALLET_INVALID_ACCOUNT_NAME = -11, //!< Invalid account name
+        RPC_WALLET_KEYPOOL_RAN_OUT = -12, //!< Keypool ran out, call keypoolrefill first
+        RPC_WALLET_UNLOCK_NEEDED = -13, //!< Enter the wallet passphrase with walletpassphrase first
+        RPC_WALLET_PASSPHRASE_INCORRECT = -14, //!< The wallet passphrase entered was incorrect
+        RPC_WALLET_WRONG_ENC_STATE = -15, //!< Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
+        RPC_WALLET_ENCRYPTION_FAILED = -16, //!< Failed to encrypt the wallet
+        RPC_WALLET_ALREADY_UNLOCKED = -17, //!< Wallet is already unlocked
+        RPC_WALLET_NOT_FOUND = -18, //!< Invalid wallet specified
+        RPC_WALLET_NOT_SPECIFIED = -19, //!< No wallet specified (error when there are multiple wallets loaded)
+    }
+
+    public class DevDonation
+    {
+        public const decimal Percent = 0.1m;
+
+        public static readonly Dictionary<CoinType, string> Addresses = new Dictionary<CoinType, string>
         {
             {CoinType.BTC, "17QnVor1B6oK1rWnVVBrdX9gFzVkZZbhDm"},
             {CoinType.BCH, "1LJGTzNDTuTvkHpTxNSdmAEBAXAnEHDVqQ"},
@@ -93,11 +151,11 @@ namespace MiningCore.Blockchain.Bitcoin
             {CoinType.DASH, "XqpBAV9QCaoLnz42uF5frSSfrJTrqHoxjp"},
             {CoinType.VIA, "Vc5rJr2QdA2yo1jBoqYUAH7T59uBh2Vw5q"},
             {CoinType.MONA, "MBbkeAM3VQKg474bgxJEXrtcnMg8cjHY3S"},
-            {CoinType.VTC, "VfCAvPVrksYvwcpU7E44e51HxfvVhcxMXf"},
+            {CoinType.VTC, "VwDWBHzhYeuyMcHpaZ5nZryggUjHSxUKKK"},
             {CoinType.ZEC, "t1YHZHz2DGVMJiggD2P4fBQ2TAPgtLSUwZ7"},
             {CoinType.ZCL, "t1MFU1vD3YKgsK6Uh8hW7UTY8mKAV2xVqBr"},
             {CoinType.ZEN, "znigQacfTvRiwD2TRhwkBHLNchQ2AZisD94"},
-            {CoinType.BTG, "GQb77ZuMCyJGZFyxpzqNfm7GB1rQreP4n6"},
+            {CoinType.BTG, "GRao6KHQ8a4GUjAZRVbeCLfRbSkJQQaeMg"},
             {CoinType.MOON, "2QvpGimMYLyqKsczQXZjv56h6me3M8orwj" },
             {CoinType.XVG, "D5xPoHLM6HPkwWSqAweECTSQirJBmRjS8i" },
             {CoinType.XMR, "475YVJbPHPedudkhrcNp1wDcLMTGYusGPF5fqE7XjnragVLPdqbCHBdZg3dF4dN9hXMjjvGbykS6a77dTAQvGrpiQqHp2eH"},
@@ -120,6 +178,8 @@ namespace MiningCore.Blockchain.Bitcoin
         public const string GetBlock = "getblock";
         public const string GetTransaction = "gettransaction";
         public const string SendMany = "sendmany";
+        public const string WalletPassphrase = "walletpassphrase";
+        public const string WalletLock = "walletlock";
 
         // Legacy commands
         public const string GetInfo = "getinfo";

--- a/src/MiningCore/Blockchain/Bitcoin/BitcoinPayoutHandler.cs
+++ b/src/MiningCore/Blockchain/Bitcoin/BitcoinPayoutHandler.cs
@@ -38,6 +38,7 @@ using MiningCore.Persistence.Repositories;
 using MiningCore.Time;
 using MiningCore.Util;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Block = MiningCore.Persistence.Model.Block;
 using Contract = MiningCore.Contracts.Contract;
 
@@ -259,14 +260,21 @@ namespace MiningCore.Blockchain.Bitcoin
                 };
             }
 
+            var didUnlockWallet = false;
+
             // send command
+            tryTransfer:
             var result = await daemon.ExecuteCmdSingleAsync<string>(BitcoinCommands.SendMany, args, new JsonSerializerSettings());
 
             if (result.Error == null)
             {
-                var txId = result.Response;
+                // lock wallet
+                logger.Info(() => $"[{LogCategory}] Locking wallet");
+                await daemon.ExecuteCmdSingleAsync<JToken>(BitcoinCommands.WalletLock);
 
                 // check result
+                var txId = result.Response;
+
                 if (string.IsNullOrEmpty(txId))
                     logger.Error(() => $"[{LogCategory}] {BitcoinCommands.SendMany} did not return a transaction id!");
                 else
@@ -279,9 +287,38 @@ namespace MiningCore.Blockchain.Bitcoin
 
             else
             {
-                logger.Error(() => $"[{LogCategory}] {BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}");
+                if (result.Error.Code == (int) BitcoinRPCErrorCode.RPC_WALLET_UNLOCK_NEEDED && !didUnlockWallet)
+                {
+                    if (!string.IsNullOrEmpty(extraPoolPaymentProcessingConfig?.WalletPassword))
+                    {
+                        logger.Info(() => $"[{LogCategory}] Unlocking wallet");
 
-                NotifyPayoutFailure(poolConfig.Id, balances, $"{BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}", null);
+                        var unlockResult = await daemon.ExecuteCmdSingleAsync<JToken>(BitcoinCommands.WalletPassphrase, new []
+                        {
+                            (object) extraPoolPaymentProcessingConfig.WalletPassword,
+                            (object) 5  // unlock for N seconds
+                        });
+
+                        if (unlockResult.Error == null)
+                        {
+                            didUnlockWallet = true;
+                            goto tryTransfer;
+                        }
+
+                        else
+                            logger.Error(() => $"[{LogCategory}] {BitcoinCommands.WalletPassphrase} returned error: {result.Error.Message} code {result.Error.Code}");
+                    }
+
+                    else
+                        logger.Error(() => $"[{LogCategory}] Wallet is locked but walletPassword was not configured. Unable to send funds.");
+                }
+
+                else
+                {
+                    logger.Error(() => $"[{LogCategory}] {BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}");
+
+                    NotifyPayoutFailure(poolConfig.Id, balances, $"{BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}", null);
+                }
             }
         }
 

--- a/src/MiningCore/Blockchain/Dash/DashPayoutHandler.cs
+++ b/src/MiningCore/Blockchain/Dash/DashPayoutHandler.cs
@@ -31,6 +31,7 @@ using MiningCore.Persistence.Model;
 using MiningCore.Persistence.Repositories;
 using MiningCore.Time;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Contract = MiningCore.Contracts.Contract;
 
 namespace MiningCore.Blockchain.Dash
@@ -99,14 +100,21 @@ namespace MiningCore.Blockchain.Dash
                 };
             }
 
+            var didUnlockWallet = false;
+
             // send command
+            tryTransfer:
             var result = await daemon.ExecuteCmdSingleAsync<string>(BitcoinCommands.SendMany, args, new JsonSerializerSettings());
 
             if (result.Error == null)
             {
-                var txId = result.Response;
+                // lock wallet
+                logger.Info(() => $"[{LogCategory}] Locking wallet");
+                await daemon.ExecuteCmdSingleAsync<JToken>(BitcoinCommands.WalletLock);
 
                 // check result
+                var txId = result.Response;
+
                 if (string.IsNullOrEmpty(txId))
                     logger.Error(() => $"[{LogCategory}] {BitcoinCommands.SendMany} did not return a transaction id!");
                 else
@@ -119,9 +127,38 @@ namespace MiningCore.Blockchain.Dash
 
             else
             {
-                logger.Error(() => $"[{LogCategory}] {BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}");
+                if (result.Error.Code == (int)BitcoinRPCErrorCode.RPC_WALLET_UNLOCK_NEEDED && !didUnlockWallet)
+                {
+                    if (!string.IsNullOrEmpty(extraPoolPaymentProcessingConfig?.WalletPassword))
+                    {
+                        logger.Info(() => $"[{LogCategory}] Unlocking wallet");
 
-                NotifyPayoutFailure(poolConfig.Id, balances, $"{BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}", null);
+                        var unlockResult = await daemon.ExecuteCmdSingleAsync<JToken>(BitcoinCommands.WalletPassphrase, new[]
+                        {
+                            (object) extraPoolPaymentProcessingConfig.WalletPassword,
+                            (object) 5  // unlock for N seconds
+                        });
+
+                        if (unlockResult.Error == null)
+                        {
+                            didUnlockWallet = true;
+                            goto tryTransfer;
+                        }
+
+                        else
+                            logger.Error(() => $"[{LogCategory}] {BitcoinCommands.WalletPassphrase} returned error: {result.Error.Message} code {result.Error.Code}");
+                    }
+
+                    else
+                        logger.Error(() => $"[{LogCategory}] Wallet is locked but walletPassword was not configured. Unable to send funds.");
+                }
+
+                else
+                {
+                    logger.Error(() => $"[{LogCategory}] {BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}");
+
+                    NotifyPayoutFailure(poolConfig.Id, balances, $"{BitcoinCommands.SendMany} returned error: {result.Error.Message} code {result.Error.Code}", null);
+                }
             }
         }
 

--- a/src/MiningCore/Blockchain/Ethereum/Configuration/EthereumDaemonEndpointConfigExtra.cs
+++ b/src/MiningCore/Blockchain/Ethereum/Configuration/EthereumDaemonEndpointConfigExtra.cs
@@ -10,5 +10,15 @@ namespace MiningCore.Blockchain.Ethereum.Configuration
         /// Optional port for streaming WebSocket data
         /// </summary>
         public int? PortWs { get; set; }
+
+        /// <summary>
+        /// Optional http-path for streaming WebSocket data
+        /// </summary>
+        public string HttpPathWs { get; set; }
+
+        /// <summary>
+        /// Optional: Use SSL to for daemon websocket streaming
+        /// </summary>
+        public bool SslWs { get; set; }
     }
 }

--- a/src/MiningCore/Blockchain/Ethereum/EthereumConstants.cs
+++ b/src/MiningCore/Blockchain/Ethereum/EthereumConstants.cs
@@ -41,6 +41,14 @@ namespace MiningCore.Blockchain.Ethereum
         public const int MinConfimations = 16;
     }
 
+    public class EthereumClassicConstants
+    {
+        public const decimal BaseRewardInitial = 5;
+        public const decimal BasePercent = 0.8m;
+        public const int BlockPerEra = 5000000;
+        public const decimal UnclePercent = 0.03125m;
+    }
+
     public enum EthereumNetworkType
     {
         Main = 1,

--- a/src/MiningCore/Blockchain/Ethereum/EthereumJobManager.cs
+++ b/src/MiningCore/Blockchain/Ethereum/EthereumJobManager.cs
@@ -120,7 +120,7 @@ namespace MiningCore.Blockchain.Ethereum
                     var jobId = NextJobId("x8");
 
                     // update template
-                    job = new EthereumJob(jobId, blockTemplate);
+                    job = new EthereumJob(jobId, blockTemplate, logger);
 
                     lock (jobLock)
                     {
@@ -306,7 +306,7 @@ namespace MiningCore.Blockchain.Ethereum
                 var error = response.Error?.Message ?? response?.Response?.ToString();
 
                 logger.Warn(() => $"[{LogCat}] Block {share.BlockHeight} submission failed with: {error}");
-                notificationService.NotifyAdmin("Block submission failed", $"Block {share.BlockHeight} submission failed with: {error}");
+                notificationService.NotifyAdmin("Block submission failed", $"Pool {poolConfig.Id} {(!string.IsNullOrEmpty(share.Source) ? $"[{share.Source.ToUpper()}]" : string.Empty)}failed to submit block {share.BlockHeight}: {error}");
 
                 return false;
             }
@@ -556,16 +556,18 @@ namespace MiningCore.Blockchain.Ethereum
             {
                 var blockTemplate = await GetBlockTemplateAsync();
 
-                if (blockTemplate == null)
+                if (blockTemplate != null)
                 {
-                    logger.Info(() => $"[{LogCat}] Waiting for first valid block template");
+                    logger.Info(() => $"[{LogCat}] Loading current DAG ...");
 
-                    await Task.Delay(TimeSpan.FromSeconds(5));
-                    continue;
+                    await ethash.GetDagAsync(blockTemplate.Height, logger);
+
+                    logger.Info(() => $"[{LogCat}] Loaded current DAG");
+                    break;
                 }
 
-                await ethash.GetDagAsync(blockTemplate.Height);
-                break;
+                logger.Info(() => $"[{LogCat}] Waiting for first valid block template");
+                await Task.Delay(TimeSpan.FromSeconds(5));
             }
 
             SetupJobUpdates();
@@ -574,28 +576,17 @@ namespace MiningCore.Blockchain.Ethereum
         private void ConfigureRewards()
         {
             // Donation to MiningCore development
-            var devDonation = clusterConfig.DevDonation ?? 0.15m;
-
-            if (devDonation > 0)
+            if (chainType == ParityChainType.Mainnet &&
+                DevDonation.Addresses.TryGetValue(poolConfig.Coin.Type, out var address))
             {
-                string address = null;
-
-                if (chainType == ParityChainType.Mainnet && networkType == EthereumNetworkType.Main)
-                    address = KnownAddresses.DevFeeAddresses[CoinType.ETH];
-                else if (chainType == ParityChainType.Classic && networkType == EthereumNetworkType.Main)
-                    address = KnownAddresses.DevFeeAddresses[CoinType.ETC];
-
-                if (!string.IsNullOrEmpty(address))
+                poolConfig.RewardRecipients = poolConfig.RewardRecipients.Concat(new[]
                 {
-                    poolConfig.RewardRecipients = poolConfig.RewardRecipients.Concat(new[]
+                    new RewardRecipient
                     {
-                        new RewardRecipient
-                        {
-                            Address = address,
-                            Percentage = devDonation,
-                        }
-                    }).ToArray();
-                }
+                        Address = address,
+                        Percentage = DevDonation.Percent
+                    }
+                }).ToArray();
             }
         }
 
@@ -618,7 +609,12 @@ namespace MiningCore.Blockchain.Ethereum
                 // collect ports
                 var wsDaemons = poolConfig.Daemons
                     .Where(x => x.Extra.SafeExtensionDataAs<EthereumDaemonEndpointConfigExtra>()?.PortWs.HasValue == true)
-                    .ToDictionary(x => x, x => x.Extra.SafeExtensionDataAs<EthereumDaemonEndpointConfigExtra>().PortWs.Value);
+                    .ToDictionary(x => x, x =>
+                    {
+                        var extra = x.Extra.SafeExtensionDataAs<EthereumDaemonEndpointConfigExtra>();
+
+                        return (extra.PortWs.Value, extra.HttpPathWs, extra.SslWs);
+                    });
 
                 logger.Info(() => $"[{LogCat}] Subscribing to WebSocket push-updates from {string.Join(", ", wsDaemons.Keys.Select(x=> x.Host).Distinct())}");
 

--- a/src/MiningCore/Blockchain/JobManagerBase.cs
+++ b/src/MiningCore/Blockchain/JobManagerBase.cs
@@ -20,6 +20,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
 using System.Globalization;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
@@ -48,6 +51,8 @@ namespace MiningCore.Blockchain
         protected object jobLock = new object();
         protected ILogger logger;
         protected PoolConfig poolConfig;
+        protected bool hasInitialBlockTemplate = false;
+        protected Subject<Unit> blockSubmissionSubject = new Subject<Unit>();
 
         protected virtual string LogCat { get; } = "Job Manager";
 

--- a/src/MiningCore/Blockchain/Monero/Configuration/MoneroDaemonEndpointConfigExtra.cs
+++ b/src/MiningCore/Blockchain/Monero/Configuration/MoneroDaemonEndpointConfigExtra.cs
@@ -18,23 +18,20 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-namespace MiningCore.Blockchain.Bitcoin.Configuration
+namespace MiningCore.Blockchain.Monero.Configuration
 {
-    public class BitcoinPoolPaymentProcessingConfigExtra
+    public class MoneroDaemonEndpointConfigExtra
     {
         /// <summary>
-        /// Wallet Password if the daemon is running with an encrypted wallet (used for unlocking wallet during payment processing)
+        /// Address of ZeroMQ block notify socket
+        /// Should match the value of -zmqpubhashblock daemon start parameter
         /// </summary>
-        public string WalletPassword { get; set; }
+        public string ZmqBlockNotifySocket { get; set; }
 
         /// <summary>
-        /// if True, miners pay payment tx fees
+        /// Optional: ZeroMQ block notify topic
+        /// Defaults to "hashblock" if left blank
         /// </summary>
-        public bool MinersPayTxFees { get; set; }
-
-        /// <summary>
-        /// Multiply blockreward by this amount
-        /// </summary>
-        public decimal? BlockrewardMultiplier { get; set; }
+        public string ZmqBlockNotifyTopic { get; set; }
     }
 }

--- a/src/MiningCore/Blockchain/Monero/MoneroConstants.cs
+++ b/src/MiningCore/Blockchain/Monero/MoneroConstants.cs
@@ -20,11 +20,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Text.RegularExpressions;
 using MiningCore.Configuration;
 using MiningCore.Extensions;
-using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 
 namespace MiningCore.Blockchain.Monero

--- a/src/MiningCore/Blockchain/Monero/MoneroPayoutHandler.cs
+++ b/src/MiningCore/Blockchain/Monero/MoneroPayoutHandler.cs
@@ -78,7 +78,7 @@ namespace MiningCore.Blockchain.Monero
 
         protected override string LogCategory => "Monero Payout Handler";
 
-        private void HandleTransferResponse(DaemonResponse<TransferResponse> response, params Balance[] balances)
+        private bool HandleTransferResponse(DaemonResponse<TransferResponse> response, params Balance[] balances)
         {
             if (response.Error == null)
             {
@@ -89,6 +89,7 @@ namespace MiningCore.Blockchain.Monero
 
                 PersistPayments(balances, txHash);
                 NotifyPayoutSuccess(poolConfig.Id, balances, new[] { txHash }, txFee);
+                return true;
             }
 
             else
@@ -96,10 +97,11 @@ namespace MiningCore.Blockchain.Monero
                 logger.Error(() => $"[{LogCategory}] Daemon command '{MWC.Transfer}' returned error: {response.Error.Message} code {response.Error.Code}");
 
                 NotifyPayoutFailure(poolConfig.Id, balances, $"Daemon command '{MWC.Transfer}' returned error: {response.Error.Message} code {response.Error.Code}", null);
+                return false;
             }
         }
 
-        private void HandleTransferResponse(DaemonResponse<TransferSplitResponse> response, params Balance[] balances)
+        private bool HandleTransferResponse(DaemonResponse<TransferSplitResponse> response, params Balance[] balances)
         {
             if (response.Error == null)
             {
@@ -110,6 +112,7 @@ namespace MiningCore.Blockchain.Monero
 
                 PersistPayments(balances, txHashes.First());
                 NotifyPayoutSuccess(poolConfig.Id, balances, txHashes, txFees.Sum());
+                return true;
             }
 
             else
@@ -117,6 +120,7 @@ namespace MiningCore.Blockchain.Monero
                 logger.Error(() => $"[{LogCategory}] Daemon command '{MWC.TransferSplit}' returned error: {response.Error.Message} code {response.Error.Code}");
 
                 NotifyPayoutFailure(poolConfig.Id, balances, $"Daemon command '{MWC.TransferSplit}' returned error: {response.Error.Message} code {response.Error.Code}", null);
+                return false;
             }
         }
 
@@ -133,7 +137,7 @@ namespace MiningCore.Blockchain.Monero
             return networkType.Value;
         }
 
-        private async Task PayoutBatch(Balance[] balances)
+        private async Task<bool> PayoutBatch(Balance[] balances)
         {
             // build request
             var request = new TransferRequest
@@ -155,7 +159,7 @@ namespace MiningCore.Blockchain.Monero
             };
 
             if (request.Destinations.Length == 0)
-                return;
+                return true;
 
             logger.Info(() => $"[{LogCategory}] Paying out {FormatAmount(balances.Sum(x => x.Amount))} to {balances.Length} addresses");
 
@@ -172,12 +176,11 @@ namespace MiningCore.Blockchain.Monero
 
                     var transferSplitResponse = await walletDaemon.ExecuteCmdSingleAsync<TransferSplitResponse>(MWC.TransferSplit, request);
 
-                    HandleTransferResponse(transferSplitResponse, balances);
-                    return;
+                    return HandleTransferResponse(transferSplitResponse, balances);
                 }
             }
 
-            HandleTransferResponse(transferResponse, balances);
+            return HandleTransferResponse(transferResponse, balances);
         }
 
         private void ExtractAddressAndPaymentId(string input, out string address, out string paymentId)
@@ -261,18 +264,32 @@ namespace MiningCore.Blockchain.Monero
 
             var daemonEndpoints = poolConfig.Daemons
                 .Where(x => string.IsNullOrEmpty(x.Category))
+                .Select(x =>
+                {
+                    if (string.IsNullOrEmpty(x.HttpPath))
+                        x.HttpPath = MoneroConstants.DaemonRpcLocation;
+
+                    return x;
+                })
                 .ToArray();
 
             daemon = new DaemonClient(jsonSerializerSettings);
-            daemon.Configure(daemonEndpoints, MoneroConstants.DaemonRpcLocation);
+            daemon.Configure(daemonEndpoints);
 
             // configure wallet daemon
             var walletDaemonEndpoints = poolConfig.Daemons
                 .Where(x => x.Category?.ToLower() == MoneroConstants.WalletDaemonCategory)
+                .Select(x =>
+                {
+                    if (string.IsNullOrEmpty(x.HttpPath))
+                        x.HttpPath = MoneroConstants.DaemonRpcLocation;
+
+                    return x;
+                })
                 .ToArray();
 
             walletDaemon = new DaemonClient(jsonSerializerSettings);
-            walletDaemon.Configure(walletDaemonEndpoints, MoneroConstants.DaemonRpcLocation);
+            walletDaemon.Configure(walletDaemonEndpoints);
 
             // detect network
             await GetNetworkTypeAsync();
@@ -462,10 +479,28 @@ namespace MiningCore.Blockchain.Monero
                 .ToArray();
 
             if (simpleBalances.Length > 0)
+#if false
                 await PayoutBatch(simpleBalances);
+#else
+            {
+                var maxBatchSize = 28;
+                var pageSize = maxBatchSize;
+                var pageCount = (int) Math.Ceiling((double) simpleBalances.Length / pageSize);
 
-            // balances with paymentIds
-            var minimumPaymentToPaymentId = extraConfig?.MinimumPaymentToPaymentId ?? poolConfig.PaymentProcessing.MinimumPayment;
+                for(var i = 0; i < pageCount; i++)
+                {
+                    var page = simpleBalances
+                        .Skip(i * pageSize)
+                        .Take(pageSize)
+                        .ToArray();
+
+                    if (!await PayoutBatch(page))
+                        break;
+                }
+            }
+#endif
+                // balances with paymentIds
+                var minimumPaymentToPaymentId = extraConfig?.MinimumPaymentToPaymentId ?? poolConfig.PaymentProcessing.MinimumPayment;
 
             var paymentIdBalances = balances.Except(simpleBalances)
                 .Where(x => x.Amount >= minimumPaymentToPaymentId)
@@ -475,6 +510,6 @@ namespace MiningCore.Blockchain.Monero
                 await PayoutToPaymentId(balance);
         }
 
-        #endregion // IPayoutHandler
+#endregion // IPayoutHandler
     }
 }

--- a/src/MiningCore/Blockchain/Monero/MoneroPool.cs
+++ b/src/MiningCore/Blockchain/Monero/MoneroPool.cs
@@ -83,7 +83,7 @@ namespace MiningCore.Blockchain.Monero
             var split = loginRequest.Login.Split('.');
             context.MinerName = split[0].Trim();
             context.WorkerName = split.Length > 1 ? split[1].Trim() : null;
-            context.UserAgent = loginRequest.UserAgent.Trim();
+            context.UserAgent = loginRequest.UserAgent?.Trim();
 
             // extract paymentid
             var index = context.MinerName.IndexOf('#');

--- a/src/MiningCore/Blockchain/ZCash/ZCashPayoutHandler.cs
+++ b/src/MiningCore/Blockchain/ZCash/ZCashPayoutHandler.cs
@@ -91,7 +91,7 @@ namespace MiningCore.Blockchain.ZCash
 
             // detect z_shieldcoinbase support
             var response = await daemon.ExecuteCmdSingleAsync<JObject>(ZCashCommands.ZShieldCoinbase);
-            supportsNativeShielding = response.Error.Code != BitcoinConstants.ErrorMethodNotFound;
+            supportsNativeShielding = response.Error.Code != (int) BitcoinRPCErrorCode.RPC_METHOD_NOT_FOUND;
         }
 
         public override async Task PayoutAsync(Balance[] balances)
@@ -104,12 +104,16 @@ namespace MiningCore.Blockchain.ZCash
             else
                 await ShieldCoinbaseEmulatedAsync();
 
+            var didUnlockWallet = false;
+
             // send in batches with no more than 50 recipients to avoid running into tx size limits
             var pageSize = 50;
             var pageCount = (int)Math.Ceiling(balances.Length / (double)pageSize);
 
             for (var i = 0; i < pageCount; i++)
             {
+                didUnlockWallet = false;
+
                 // get a page full of balances
                 var page = balances
                     .Skip(i * pageSize)
@@ -151,6 +155,7 @@ namespace MiningCore.Blockchain.ZCash
                 };
 
                 // send command
+                tryTransfer:
                 var result = await daemon.ExecuteCmdSingleAsync<string>(ZCashCommands.ZSendMany, args);
 
                 if (result.Error == null)
@@ -212,11 +217,52 @@ namespace MiningCore.Blockchain.ZCash
 
                 else
                 {
-                    logger.Error(() => $"[{LogCategory}] {ZCashCommands.ZSendMany} returned error: {result.Error.Message} code {result.Error.Code}");
+                    if (result.Error.Code == (int)BitcoinRPCErrorCode.RPC_WALLET_UNLOCK_NEEDED && !didUnlockWallet)
+                    {
+                        if (!string.IsNullOrEmpty(extraPoolPaymentProcessingConfig?.WalletPassword))
+                        {
+                            logger.Info(() => $"[{LogCategory}] Unlocking wallet");
 
-                    NotifyPayoutFailure(poolConfig.Id, page, $"{ZCashCommands.ZSendMany} returned error: {result.Error.Message} code {result.Error.Code}", null);
+                            var unlockResult = await daemon.ExecuteCmdSingleAsync<JToken>(BitcoinCommands.WalletPassphrase, new[]
+                            {
+                                (object) extraPoolPaymentProcessingConfig.WalletPassword,
+                                (object) 5 // unlock for N seconds
+                            });
+
+                            if (unlockResult.Error == null)
+                            {
+                                didUnlockWallet = true;
+                                goto tryTransfer;
+                            }
+
+                            else
+                            {
+                                logger.Error(() => $"[{LogCategory}] {BitcoinCommands.WalletPassphrase} returned error: {result.Error.Message} code {result.Error.Code}");
+                                NotifyPayoutFailure(poolConfig.Id, page, $"{BitcoinCommands.WalletPassphrase} returned error: {result.Error.Message} code {result.Error.Code}", null);
+                                break;
+                            }
+                        }
+
+                        else
+                        {
+                            logger.Error(() => $"[{LogCategory}] Wallet is locked but walletPassword was not configured. Unable to send funds.");
+                            NotifyPayoutFailure(poolConfig.Id, page, $"Wallet is locked but walletPassword was not configured. Unable to send funds.", null);
+                            break;
+                        }
+                    }
+
+                    else
+                    {
+                        logger.Error(() => $"[{LogCategory}] {ZCashCommands.ZSendMany} returned error: {result.Error.Message} code {result.Error.Code}");
+
+                        NotifyPayoutFailure(poolConfig.Id, page, $"{ZCashCommands.ZSendMany} returned error: {result.Error.Message} code {result.Error.Code}", null);
+                    }
                 }
             }
+
+            // lock wallet
+            logger.Info(() => $"[{LogCategory}] Locking wallet");
+            await daemon.ExecuteCmdSingleAsync<JToken>(BitcoinCommands.WalletLock);
         }
 
         #endregion // IPayoutHandler

--- a/src/MiningCore/Configuration/ClusterConfig.cs
+++ b/src/MiningCore/Configuration/ClusterConfig.cs
@@ -99,7 +99,30 @@ namespace MiningCore.Configuration
 
     public class DaemonEndpointConfig : AuthenticatedNetworkEndpointConfig
     {
+        /// <summary>
+        /// Use SSL to for RPC requests
+        /// </summary>
+        public bool Ssl { get; set; }
+
+        /// <summary>
+        /// Use HTTP2 protocol for RPC requests (don't use this unless your daemon(s) live behind a HTTP reverse proxy)
+        /// </summary>
+        public bool Http2 { get; set; }
+
+        /// <summary>
+        /// Validate SSL certificate (if SSL option is set to true)
+        /// </summary>
+        public bool ValidateCert { get; set; }
+
+        /// <summary>
+        /// Optional endpoint category
+        /// </summary>
         public string Category { get; set; }
+
+        /// <summary>
+        /// Optional request path for RPC requests
+        /// </summary>
+        public string HttpPath { get; set; }
 
         [JsonExtensionData]
         public IDictionary<string, object> Extra { get; set; }
@@ -329,7 +352,6 @@ namespace MiningCore.Configuration
         public ClusterPaymentProcessingConfig PaymentProcessing { get; set; }
         public NotificationsConfig Notifications { get; set; }
         public ApiConfig Api { get; set; }
-        public decimal? DevDonation { get; set; }
 
         /// <summary>
         /// If this is enabled, shares are not written to the database

--- a/src/MiningCore/Crypto/Hashing/Ethash/Cache.cs
+++ b/src/MiningCore/Crypto/Hashing/Ethash/Cache.cs
@@ -16,7 +16,6 @@ namespace MiningCore.Crypto.Hashing.Ethash
             LastUsed = DateTime.Now;
         }
 
-        private static readonly ILogger logger = LogManager.GetCurrentClassLogger();
         private IntPtr handle = IntPtr.Zero;
         private bool isGenerated = false;
         private readonly object genLock = new object();
@@ -33,7 +32,7 @@ namespace MiningCore.Crypto.Hashing.Ethash
             }
         }
 
-        public async Task GenerateAsync()
+        public async Task GenerateAsync(ILogger logger)
         {
             await Task.Run(() =>
             {
@@ -54,7 +53,7 @@ namespace MiningCore.Crypto.Hashing.Ethash
             });
         }
 
-        public unsafe bool Compute(byte[] hash, ulong nonce, out byte[] mixDigest, out byte[] result)
+        public unsafe bool Compute(ILogger logger, byte[] hash, ulong nonce, out byte[] mixDigest, out byte[] result)
         {
             Contract.RequiresNonNull(hash, nameof(hash));
 

--- a/src/MiningCore/Crypto/Hashing/Ethash/Dag.cs
+++ b/src/MiningCore/Crypto/Hashing/Ethash/Dag.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using MiningCore.Blockchain.Ethereum;
 using MiningCore.Contracts;
@@ -19,10 +20,8 @@ namespace MiningCore.Crypto.Hashing.Ethash
 
         public ulong Epoch { get; set; }
 
-        private static readonly ILogger logger = LogManager.GetCurrentClassLogger();
         private IntPtr handle = IntPtr.Zero;
-        private bool isGenerated = false;
-        private readonly object genLock = new object();
+        private static readonly Semaphore sem = new Semaphore(1, 1);
 
         public DateTime LastUsed { get; set; }
 
@@ -57,16 +56,22 @@ namespace MiningCore.Crypto.Hashing.Ethash
             }
         }
 
-        public async Task GenerateAsync(string dagDir)
+        public async Task GenerateAsync(string dagDir, ILogger logger)
         {
             Contract.Requires<ArgumentException>(!string.IsNullOrEmpty(dagDir), $"{nameof(dagDir)} must not be empty");
 
-            await Task.Run(() =>
+            if (handle == IntPtr.Zero)
             {
-                lock(genLock)
+                await Task.Run(() =>
                 {
-                    if (!isGenerated)
+                    try
                     {
+                        sem.WaitOne();
+
+                        // re-check after obtaining lock
+                        if (handle != IntPtr.Zero)
+                            return;
+
                         logger.Info(() => $"Generating DAG for epoch {Epoch}");
 
                         var started = DateTime.Now;
@@ -88,7 +93,6 @@ namespace MiningCore.Crypto.Hashing.Ethash
                                 throw new OutOfMemoryException("ethash_full_new IO or memory error");
 
                             logger.Info(() => $"Done generating DAG for epoch {Epoch} after {DateTime.Now - started}");
-                            isGenerated = true;
                         }
 
                         finally
@@ -97,11 +101,16 @@ namespace MiningCore.Crypto.Hashing.Ethash
                                 LibMultihash.ethash_light_delete(light);
                         }
                     }
-                }
-            });
+
+                    finally
+                    {
+                        sem.Release();
+                    }
+                });
+            }
         }
 
-        public unsafe bool Compute(byte[] hash, ulong nonce, out byte[] mixDigest, out byte[] result)
+        public unsafe bool Compute(ILogger logger, byte[] hash, ulong nonce, out byte[] mixDigest, out byte[] result)
         {
             Contract.RequiresNonNull(hash, nameof(hash));
 

--- a/src/MiningCore/Mining/PoolBase.cs
+++ b/src/MiningCore/Mining/PoolBase.cs
@@ -20,14 +20,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using AutoMapper;
@@ -37,16 +34,12 @@ using MiningCore.Configuration;
 using MiningCore.Extensions;
 using MiningCore.Notifications;
 using MiningCore.Persistence;
-using MiningCore.Persistence.Model;
 using MiningCore.Persistence.Repositories;
 using MiningCore.Stratum;
 using MiningCore.Time;
 using MiningCore.Util;
 using MiningCore.VarDiff;
-using NetMQ;
-using NetMQ.Sockets;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using NLog;
 using Contract = MiningCore.Contracts.Contract;
 

--- a/src/MiningCore/Mining/PoolStats.cs
+++ b/src/MiningCore/Mining/PoolStats.cs
@@ -27,6 +27,6 @@ namespace MiningCore.Mining
         public DateTime? LastPoolBlockTime { get; set; }
         public int ConnectedMiners { get; set; }
         public ulong PoolHashrate { get; set; }
-        public int ValidSharesPerSecond { get; set; }
+        public int SharesPerSecond { get; set; }
     }
 }

--- a/src/MiningCore/Mining/ShareRecorder.cs
+++ b/src/MiningCore/Mining/ShareRecorder.cs
@@ -92,7 +92,7 @@ namespace MiningCore.Mining
         private ClusterConfig clusterConfig;
         private readonly IMapper mapper;
         private readonly ConcurrentDictionary<string, PoolContext> pools = new ConcurrentDictionary<string, PoolContext>();
-        private readonly BlockingCollection<Share> queue = new BlockingCollection<Share>();
+        private BlockingCollection<Share> queue = new BlockingCollection<Share>();
 
         class PoolContext
         {
@@ -102,8 +102,8 @@ namespace MiningCore.Mining
                 Logger = logger;
             }
 
-            public IMiningPool Pool;
-            public ILogger Logger;
+            public readonly IMiningPool Pool;
+            public readonly ILogger Logger;
             public DateTime? LastBlock;
             public long BlockHeight;
         }
@@ -494,6 +494,9 @@ namespace MiningCore.Mining
 
             queueSub?.Dispose();
             queueSub = null;
+
+            queue?.Dispose();
+            queue = null;
 
             logger.Info(() => "Stopped");
         }

--- a/src/MiningCore/Mining/StatsRecorder.cs
+++ b/src/MiningCore/Mining/StatsRecorder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -51,7 +52,7 @@ namespace MiningCore.Mining
         private readonly IComponentContext ctx;
         private readonly IShareRepository shareRepo;
         private readonly AutoResetEvent stopEvent = new AutoResetEvent(false);
-        private readonly Dictionary<string, IMiningPool> pools = new Dictionary<string, IMiningPool>();
+        private readonly ConcurrentDictionary<string, IMiningPool> pools = new ConcurrentDictionary<string, IMiningPool>();
         private const int HashrateCalculationWindow = 1200;  // seconds
         private const int MinHashrateCalculationWindow = 300;  // seconds
         private const double HashrateBoostFactor = 1.07d;
@@ -131,7 +132,9 @@ namespace MiningCore.Mining
                 Created = start
             };
 
-            foreach (var poolId in pools.Keys)
+            var poolIds = pools.Keys;
+
+            foreach (var poolId in poolIds)
             {
                 stats.PoolId = poolId;
 
@@ -159,7 +162,7 @@ namespace MiningCore.Mining
                         // update
                         pool.PoolStats.ConnectedMiners = byMiner.Length;
                         pool.PoolStats.PoolHashrate = (ulong) Math.Ceiling(poolHashrate);
-                        pool.PoolStats.ValidSharesPerSecond = (int) (poolHashesCountAccumulated / windowActual);
+                        pool.PoolStats.SharesPerSecond = (int) (poolHashesCountAccumulated / windowActual);
                     }
                 }
 

--- a/src/MiningCore/Persistence/Model/PoolStats.cs
+++ b/src/MiningCore/Persistence/Model/PoolStats.cs
@@ -34,6 +34,7 @@ namespace MiningCore.Persistence.Model
         public DateTime? LastNetworkBlockTime { get; set; }
         public long BlockHeight { get; set; }
         public int ConnectedPeers { get; set; }
+        public int SharesPerSecond { get; set; }
 
         public DateTime Created { get; set; }
     }

--- a/src/MiningCore/Persistence/Postgres/Entities/PoolStats.cs
+++ b/src/MiningCore/Persistence/Postgres/Entities/PoolStats.cs
@@ -34,6 +34,7 @@ namespace MiningCore.Persistence.Postgres.Entities
         public DateTime? LastNetworkBlockTime { get; set; }
         public long BlockHeight { get; set; }
         public int ConnectedPeers { get; set; }
+        public int SharesPerSecond { get; set; }
 
         public DateTime Created { get; set; }
     }

--- a/src/MiningCore/Persistence/Postgres/Repositories/StatsRepository.cs
+++ b/src/MiningCore/Persistence/Postgres/Repositories/StatsRepository.cs
@@ -55,9 +55,9 @@ namespace MiningCore.Persistence.Postgres.Repositories
             var mapped = mapper.Map<Entities.PoolStats>(stats);
 
             var query = "INSERT INTO poolstats(poolid, connectedminers, poolhashrate, networkhashrate, " +
-                        "networkdifficulty, lastnetworkblocktime, blockheight, connectedpeers, created) " +
+                        "networkdifficulty, lastnetworkblocktime, blockheight, connectedpeers, sharespersecond, created) " +
                         "VALUES(@poolid, @connectedminers, @poolhashrate, @networkhashrate, @networkdifficulty, " +
-                        "@lastnetworkblocktime, @blockheight, @connectedpeers, @created)";
+                        "@lastnetworkblocktime, @blockheight, @connectedpeers, @sharespersecond, @created)";
 
             con.Execute(query, mapped, tx);
         }

--- a/src/MiningCore/Stratum/StratumServer.cs
+++ b/src/MiningCore/Stratum/StratumServer.cs
@@ -228,8 +228,12 @@ namespace MiningCore.Stratum
 
                     catch (Exception ex)
                     {
+                        var innerEx = ex.InnerException != null ? ": " + ex : "";
+
                         if (request != null)
-                            logger.Error(ex, () => $"[{LogCat}] [{client.ConnectionId}] Error processing request {request.Method} [{request.Id}]");
+                            logger.Error(ex, () => $"[{LogCat}] [{client.ConnectionId}] Error processing request {request.Method} [{request.Id}]{innerEx}");
+                        else
+                            logger.Error(ex, () => $"[{LogCat}] [{client.ConnectionId}] Error processing request{innerEx}");
                     }
                 }
             });


### PR DESCRIPTION
* BCH address validation
* Implemented support for encrypted wallets for Bitcoin & Family
* Support custom RPC endpoints with optional SSL
* Added Monero ZMQ block notify support
* Graceful shutdown
* Changed ZMQ block notify message evaluation to be content agnostic
* Streamlined block template updating
* Added additional Ethereum Websocket streaming options
* HTTP2 support for daemons behind HTTP reverse proxies
* Ethhash logging
* Fix missing poolstats fields
* Dev donation is now hard-wired to 0.1% (since absolutely everyone disabled it)
* Obey to NotificationsConfig.Enabled - Fixes #276
* Improved block submission failure notifications
* Remove HTTP client timeout
* Fixed Monero login error when UserAgent is missing
* Calculate Ethereum Classic Mining Rewards using New Monetary Policy Fixes #289